### PR TITLE
Implement winner absence functionality and improve container management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINER_NAME = ghspain-sorteo-app
 build:
 	docker build -t $(IMAGE_NAME) .
 
-run: build
+run: build stop
 	docker run -d --name $(CONTAINER_NAME) -p 8501:8501 $(IMAGE_NAME)
 
 clean:

--- a/app.py
+++ b/app.py
@@ -197,6 +197,25 @@ def delete_round(round_idx):
     # Remove the round configuration
     st.session_state.rounds.pop(round_idx)
 
+def get_prize_for_winner_index(index, round_config):
+    """
+    Helper function to retrieve prize for a winner based on their index.
+
+    Args:
+        index: The index position of the winner in the original winners list
+        round_config: Configuration for the round containing prizes
+
+    Returns:
+        str: Prize name or '-' if no prize is assigned
+    """
+    if not round_config or not round_config.get('prizes'):
+        return '-'
+
+    if index >= 0 and index < len(round_config['prizes']):
+        return round_config['prizes'][index]['name']
+
+    return '-'
+
 def assign_prize(winner, winners, round_config):
     """
     Determine the prize for a winner based on their status (original or replacement).
@@ -209,28 +228,21 @@ def assign_prize(winner, winners, round_config):
     Returns:
         str: Prize name or '-' if no prize is assigned
     """
-    # Default value if no prize is found
-    prize_name = '-'
-
-    # No prize assignment possible if there's no round config or prizes
-    if not round_config or not round_config.get('prizes'):
-        return prize_name
+    # Get list of original winners (non-replacements)
+    original_winners = [w for w in winners if not w.get('is_replacement')]
 
     # For replacements, find the prize of the original winner they replaced
     if winner.get('is_replacement') and winner.get('replaced'):
-        # Find the original winner this replaced
-        original_winners = [w for w in winners if not w.get('is_replacement')]
         for idx, orig_winner in enumerate(original_winners):
-            if orig_winner.get('Email') == winner.get('replaced') and idx < len(round_config['prizes']):
-                return round_config['prizes'][idx]['name']
+            if orig_winner.get('Email') == winner.get('replaced'):
+                return get_prize_for_winner_index(idx, round_config)
+
     # For original winners (not replacements)
     elif not winner.get('is_replacement'):
-        original_winners = [w for w in winners if not w.get('is_replacement')]
         idx = original_winners.index(winner) if winner in original_winners else -1
-        if idx >= 0 and idx < len(round_config['prizes']):
-            return round_config['prizes'][idx]['name']
+        return get_prize_for_winner_index(idx, round_config)
 
-    return prize_name
+    return '-'
 
 def mark_winner_absent(round_id, winner_index):
     """Mark a winner as absent and redraw a replacement"""

--- a/app.py
+++ b/app.py
@@ -64,6 +64,16 @@ st.markdown("""
     border-radius: 5px;
     margin-bottom: 10px;
 }
+.winner-card.absent {
+    background-color: rgba(255, 0, 0, 0.1);
+    border: 1px solid #ff0000;
+    opacity: 0.7;
+}
+.absent-label {
+    color: #ff0000;
+    font-weight: bold;
+    margin-top: 5px;
+}
 </style>
 """, unsafe_allow_html=True)
 
@@ -78,6 +88,8 @@ if 'session_id' not in st.session_state:
     st.session_state.session_id = str(uuid.uuid4())
 if 'drawn_winners' not in st.session_state:
     st.session_state.drawn_winners = {}  # Dictionary to store winners by round
+if 'absent_participants' not in st.session_state:
+    st.session_state.absent_participants = []  # List to store absent participants' emails
 
 def reset_session():
     """Reset the session completely"""
@@ -86,6 +98,7 @@ def reset_session():
     st.session_state.rounds = []
     st.session_state.session_id = str(uuid.uuid4())
     st.session_state.drawn_winners = {}
+    st.session_state.absent_participants = []
 
 def process_csv(uploaded_file, only_checkin=True):
     """Process uploaded CSV file and filter participants"""
@@ -136,8 +149,11 @@ def draw_winners(participants_df, num_winners, exclude_emails=None):
     if exclude_emails is None:
         exclude_emails = []
 
-    # Filter out previous winners
-    available_participants = participants_df[~participants_df['Email'].isin(exclude_emails)]
+    # Combine previous winners and absent participants to exclude from drawing
+    all_excluded_emails = list(set(exclude_emails + st.session_state.absent_participants))
+
+    # Filter out previous winners and absent participants
+    available_participants = participants_df[~participants_df['Email'].isin(all_excluded_emails)]
 
     if len(available_participants) < num_winners:
         st.error(f"No hay suficientes participantes disponibles. Solicitados: {num_winners}, Disponibles: {len(available_participants)}")
@@ -181,6 +197,56 @@ def delete_round(round_idx):
     # Remove the round configuration
     st.session_state.rounds.pop(round_idx)
 
+def mark_winner_absent(round_id, winner_index):
+    """Mark a winner as absent and redraw a replacement"""
+    if round_id not in st.session_state.drawn_winners:
+        return
+
+    winners = st.session_state.drawn_winners[round_id]
+    if winner_index >= len(winners):
+        return
+
+    # Get the winner to mark as absent
+    absent_winner = winners[winner_index]
+
+    # Check if the winner doesn't have the absent flag yet
+    if 'absent' not in absent_winner or not absent_winner['absent']:
+        # Mark as absent
+        absent_winner['absent'] = True
+
+        # Add to absent participants list if not already there
+        if absent_winner['Email'] not in st.session_state.absent_participants:
+            st.session_state.absent_participants.append(absent_winner['Email'])
+
+        # Find the corresponding round configuration
+        round_config = next((r for r in st.session_state.rounds if r['id'] == round_id), None)
+        if round_config:
+            # Try to draw a replacement winner
+            replacement = draw_winners(
+                st.session_state.participants,
+                1,
+                exclude_emails=st.session_state.all_winners
+            )
+
+            if replacement:
+                replacement_winner = replacement[0]
+                # Add a flag to identify it as a replacement
+                replacement_winner['is_replacement'] = True
+                # Store reference to the original absent winner
+                replacement_winner['replaced'] = absent_winner['Email']
+
+                # Add to global winners list
+                st.session_state.all_winners.append(replacement_winner['Email'])
+
+                # Add to the winners list for this round
+                winners.append(replacement_winner)
+
+                return True
+            else:
+                st.warning("No hay participantes disponibles para reemplazar al ganador ausente.")
+                return False
+    return False
+
 # Sidebar for configuration
 with st.sidebar:
     st.title("🎲 Configuración del Sorteo")
@@ -214,7 +280,21 @@ with st.sidebar:
     st.text(f"Fecha: {datetime.now().strftime('%Y-%m-%d %H:%M')}")
     if st.session_state.participants is not None:
         st.text(f"Participantes: {len(st.session_state.participants)}")
-    st.text(f"Ganadores totales: {len(st.session_state.all_winners)}")
+
+    # Count different types of winners
+    total_winners = len(st.session_state.all_winners)
+
+    # Calculate number of absent winners (those marked as absent)
+    absent_winners = len(st.session_state.absent_participants)
+
+    # Calculate final winners (total winners excluding absent ones)
+    final_winners = total_winners - absent_winners
+
+    # Display winner statistics with clearer differentiation
+    st.markdown("**Estadísticas de Ganadores**")
+    st.text(f"Total de ganadores sorteados: {total_winners}")
+    st.text(f"Ganadores ausentes: {absent_winners}")
+    st.text(f"Receptores finales de premios: {final_winners}")
 
 # Main content area
 st.title("🎉 Sorteo de Eventos")
@@ -316,23 +396,53 @@ else:
         # Display winners for this round
         if round_id in st.session_state.drawn_winners and st.session_state.drawn_winners[round_id]:
             st.subheader("Ganadores de esta ronda")
-            
+
             winners = st.session_state.drawn_winners[round_id]
-            cols = st.columns(min(3, len(winners)))
-            
-            for j, winner in enumerate(winners):
+            replacements = [w for w in winners if w.get('is_replacement')]
+            original_winners = [w for w in winners if not w.get('is_replacement')]
+
+            # Display original winners first, then replacements
+            all_display_winners = original_winners + replacements
+            cols = st.columns(min(3, len(all_display_winners)))
+
+            for j, winner in enumerate(all_display_winners):
                 with cols[j % len(cols)]:
-                    st.markdown(f"""
-                    <div class="winner-card">
+                    # Determine CSS class based on absent status
+                    card_class = "winner-card absent" if winner.get('absent') else "winner-card"
+
+                    # Build winner card HTML
+                    card_html = f"""
+                    <div class="{card_class}">
                         <h4>{winner['First Name']} {winner['Last Name']}</h4>
                         <p>{mask_email(winner['Email'])}</p>
-                    </div>
-                    """, unsafe_allow_html=True)
-                    
-                    # Assign prize if available
-                    if j < len(round_config['prizes']):
-                        prize = round_config['prizes'][j]
+                    """
+
+                    # Add absent label if applicable
+                    if winner.get('absent'):
+                        card_html += '<p class="absent-label">Ausente</p>'
+
+                    # Add replacement info if applicable
+                    if winner.get('is_replacement'):
+                        replaced_email = winner.get('replaced', '')
+                        card_html += f'<p><small>Reemplazo para: {mask_email(replaced_email)}</small></p>'
+
+                    # Close the div
+                    card_html += '</div>'
+
+                    # Render the card
+                    st.markdown(card_html, unsafe_allow_html=True)
+
+                    # Assign prize if available and not a replacement
+                    prize_index = original_winners.index(winner) if winner in original_winners else -1
+                    if prize_index >= 0 and prize_index < len(round_config['prizes']):
+                        prize = round_config['prizes'][prize_index]
                         st.info(f"Premio: {prize['name']}")
+
+                    # Mark as absent button (show for any non-absent winner, including replacements)
+                    if not winner.get('absent'):
+                        if st.button("Marcar como ausente", key=f"mark_absent_{round_id}_{j}"):
+                            if mark_winner_absent(round_id, winners.index(winner)):
+                                st.experimental_rerun()
 
         st.markdown("---")
 
@@ -348,13 +458,40 @@ else:
                 winner_data = {
                     'Ronda': round_name,
                     'Nombre': f"{winner['First Name']} {winner['Last Name']}",
-                    'Email': mask_email(winner['Email'])
+                    'Email': mask_email(winner['Email']),
+                    'Estado': 'Ausente' if winner.get('absent') else 'Presente',
+                    'Tipo': 'Reemplazo' if winner.get('is_replacement') else 'Original'
                 }
+
+                # Add replacement info if applicable
+                if winner.get('is_replacement') and winner.get('replaced'):
+                    winner_data['Reemplazo para'] = mask_email(winner.get('replaced'))
+                else:
+                    winner_data['Reemplazo para'] = '-'
 
                 # Add prize info if available
                 round_config = next((r for r in st.session_state.rounds if r['id'] == round_id), None)
-                if round_config and i < len(round_config['prizes']):
-                    winner_data['Premio'] = round_config['prizes'][i]['name']
+                if round_config:
+                    # For replacements, find the prize of the original winner they replaced
+                    if winner.get('is_replacement') and winner.get('replaced'):
+                        # Find the original winner this replaced
+                        original_winners = [w for w in winners if not w.get('is_replacement')]
+                        for idx, orig_winner in enumerate(original_winners):
+                            if orig_winner.get('Email') == winner.get('replaced') and idx < len(round_config['prizes']):
+                                winner_data['Premio'] = round_config['prizes'][idx]['name']
+                                break
+                        else:
+                            winner_data['Premio'] = '-'
+                    # For original winners (not replacements)
+                    elif not winner.get('is_replacement'):
+                        original_winners = [w for w in winners if not w.get('is_replacement')]
+                        idx = original_winners.index(winner) if winner in original_winners else -1
+                        if idx >= 0 and idx < len(round_config['prizes']):
+                            winner_data['Premio'] = round_config['prizes'][idx]['name']
+                        else:
+                            winner_data['Premio'] = '-'
+                    else:
+                        winner_data['Premio'] = '-'
                 else:
                     winner_data['Premio'] = '-'
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ import io
 import uuid
 from datetime import datetime
 
+# Constants to avoid duplication
+CHECKIN_DATE_COLUMN = 'Checkin Date (UTC)'
+
 def mask_email(email):
     """Mask email to protect privacy (e.g., j***e@d***n.com)"""
     if not email or '@' not in email:
@@ -109,7 +112,7 @@ def process_csv(uploaded_file, only_checkin=True):
 
         # Check for required columns
         expected_columns = [
-            ('Checkin Date (UTC)', 'checked_in_at'),
+            (CHECKIN_DATE_COLUMN, 'checked_in_at'),
             ('Email', 'email'),
             ('First Name', 'first_name'),
             ('Last Name', 'last_name')
@@ -133,8 +136,8 @@ def process_csv(uploaded_file, only_checkin=True):
 
         # Filter participants based on check-in status
         if only_checkin:
-            participants_df = participants_df[participants_df['Checkin Date (UTC)'].notna() &
-                                             (participants_df['Checkin Date (UTC)'] != '')]
+            participants_df = participants_df[participants_df[CHECKIN_DATE_COLUMN].notna() &
+                                             (participants_df[CHECKIN_DATE_COLUMN] != '')]
 
         # Filter out specific email domains if needed
         participants_df = participants_df[~participants_df['Email'].str.contains('bevylabs', case=False, na=False)]
@@ -364,7 +367,7 @@ else:
         # Create a display dataframe with masked emails
         display_df = st.session_state.participants.copy()
         display_df['Email'] = display_df['Email'].apply(mask_email)
-        st.dataframe(display_df[['First Name', 'Last Name', 'Email', 'Checkin Date (UTC)']])
+        st.dataframe(display_df[['First Name', 'Last Name', 'Email', CHECKIN_DATE_COLUMN]])
 
     # Display and configure rounds
     if not st.session_state.rounds:
@@ -450,10 +453,13 @@ else:
 
             # Display original winners first, then replacements
             all_display_winners = original_winners + replacements
-            cols = st.columns(min(3, len(all_display_winners)))
+
+            # Create the right number of columns based on number of winners
+            num_cols = min(3, len(all_display_winners))
+            cols = st.columns(num_cols)
 
             for j, winner in enumerate(all_display_winners):
-                with cols[j % len(cols)]:
+                with cols[j % num_cols]:
                     # Determine CSS class based on absent status
                     card_class = "winner-card absent" if winner.get('absent') else "winner-card"
 
@@ -500,7 +506,7 @@ else:
         for round_id, winners in st.session_state.drawn_winners.items():
             round_name = next((r['name'] for r in st.session_state.rounds if r['id'] == round_id), f"Ronda {round_id}")
 
-            for i, winner in enumerate(winners):
+            for winner in winners:
                 winner_data = {
                     'Ronda': round_name,
                     'Nombre': f"{winner['First Name']} {winner['Last Name']}",

--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ if 'absent_participants' not in st.session_state:
 def reset_session():
     """Reset the session completely"""
     st.session_state.participants = None
-    st.session_state.all_winners = []
+    st.session_state.all_winners = []  # Reset all winners list to prevent key errors when drawing replacements
     st.session_state.rounds = []
     st.session_state.session_id = str(uuid.uuid4())
     st.session_state.drawn_winners = {}

--- a/app.py
+++ b/app.py
@@ -197,6 +197,41 @@ def delete_round(round_idx):
     # Remove the round configuration
     st.session_state.rounds.pop(round_idx)
 
+def assign_prize(winner, winners, round_config):
+    """
+    Determine the prize for a winner based on their status (original or replacement).
+
+    Args:
+        winner: The winner record
+        winners: List of all winners in the round
+        round_config: Configuration for the round containing prizes
+
+    Returns:
+        str: Prize name or '-' if no prize is assigned
+    """
+    # Default value if no prize is found
+    prize_name = '-'
+
+    # No prize assignment possible if there's no round config or prizes
+    if not round_config or not round_config.get('prizes'):
+        return prize_name
+
+    # For replacements, find the prize of the original winner they replaced
+    if winner.get('is_replacement') and winner.get('replaced'):
+        # Find the original winner this replaced
+        original_winners = [w for w in winners if not w.get('is_replacement')]
+        for idx, orig_winner in enumerate(original_winners):
+            if orig_winner.get('Email') == winner.get('replaced') and idx < len(round_config['prizes']):
+                return round_config['prizes'][idx]['name']
+    # For original winners (not replacements)
+    elif not winner.get('is_replacement'):
+        original_winners = [w for w in winners if not w.get('is_replacement')]
+        idx = original_winners.index(winner) if winner in original_winners else -1
+        if idx >= 0 and idx < len(round_config['prizes']):
+            return round_config['prizes'][idx]['name']
+
+    return prize_name
+
 def mark_winner_absent(round_id, winner_index):
     """Mark a winner as absent and redraw a replacement"""
     if round_id not in st.session_state.drawn_winners:
@@ -433,10 +468,9 @@ else:
                     st.markdown(card_html, unsafe_allow_html=True)
 
                     # Assign prize if available and not a replacement
-                    prize_index = original_winners.index(winner) if winner in original_winners else -1
-                    if prize_index >= 0 and prize_index < len(round_config['prizes']):
-                        prize = round_config['prizes'][prize_index]
-                        st.info(f"Premio: {prize['name']}")
+                    prize_name = assign_prize(winner, winners, round_config)
+                    if prize_name != '-':
+                        st.info(f"Premio: {prize_name}")
 
                     # Mark as absent button (show for any non-absent winner, including replacements)
                     if not winner.get('absent'):
@@ -469,31 +503,8 @@ else:
                 else:
                     winner_data['Reemplazo para'] = '-'
 
-                # Add prize info if available
-                round_config = next((r for r in st.session_state.rounds if r['id'] == round_id), None)
-                if round_config:
-                    # For replacements, find the prize of the original winner they replaced
-                    if winner.get('is_replacement') and winner.get('replaced'):
-                        # Find the original winner this replaced
-                        original_winners = [w for w in winners if not w.get('is_replacement')]
-                        for idx, orig_winner in enumerate(original_winners):
-                            if orig_winner.get('Email') == winner.get('replaced') and idx < len(round_config['prizes']):
-                                winner_data['Premio'] = round_config['prizes'][idx]['name']
-                                break
-                        else:
-                            winner_data['Premio'] = '-'
-                    # For original winners (not replacements)
-                    elif not winner.get('is_replacement'):
-                        original_winners = [w for w in winners if not w.get('is_replacement')]
-                        idx = original_winners.index(winner) if winner in original_winners else -1
-                        if idx >= 0 and idx < len(round_config['prizes']):
-                            winner_data['Premio'] = round_config['prizes'][idx]['name']
-                        else:
-                            winner_data['Premio'] = '-'
-                    else:
-                        winner_data['Premio'] = '-'
-                else:
-                    winner_data['Premio'] = '-'
+                # Add prize info
+                winner_data['Premio'] = assign_prize(winner, winners, next((r for r in st.session_state.rounds if r['id'] == round_id), None))
 
                 all_winners_data.append(winner_data)
 


### PR DESCRIPTION

This pull request introduces functionality to handle absent winners in a raffle application, enhancing the user experience and improving clarity in winner management. The changes include tracking absent participants, marking winners as absent, redrawing replacements, and updating the UI to reflect these updates.

### New Features for Absent Winner Handling:
* Added a new session state variable, `absent_participants`, to track emails of absent winners. This is integrated into the session reset logic. (`app.py`: [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R91-R92) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R101)
* Introduced a `mark_winner_absent` function to mark winners as absent, add them to the absent participants list, and redraw replacements if possible. Replacement winners are flagged and linked to the original absent winners. (`app.py`: [app.pyR200-R249](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R200-R249))

### Enhancements to Winner Display and Statistics:
* Updated the winner display logic to differentiate between original winners and replacements. Added visual indicators for absent winners and replacement winners in the UI. (`app.py`: [app.pyL321-R446](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L321-R446))
* Enhanced statistics to show total winners, absent winners, and final prize recipients, providing clearer insights into the raffle outcome. (`app.py`: [app.pyL217-R297](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L217-R297))

### Prize Assignment Improvements:
* Adjusted prize assignment logic to account for replacements, ensuring prizes are correctly matched with original winners or their replacements. (`app.py`: [app.pyL351-R494](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L351-R494))

### Minor Changes:
* Updated the `Makefile` to ensure the `run` target stops any existing container before starting a new one, improving reliability during development. (`Makefile`: [MakefileL9-R9](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L9-R9))